### PR TITLE
Fix list search

### DIFF
--- a/src/FormSubmissionList.php
+++ b/src/FormSubmissionList.php
@@ -168,6 +168,9 @@ class FormSubmissionList extends DataObject
                 }
             }
         }
+        if (method_exists($this->TargetClass, 'updateExportColumns')) {
+            $this->TargetClass::updateExportColumns($fields);
+        }
         return $fields;
     }
 

--- a/src/FormSubmissionList.php
+++ b/src/FormSubmissionList.php
@@ -68,7 +68,7 @@ class FormSubmissionList extends DataObject
         $dataClasses = ClassInfo::subclassesFor(DataObject::class);
         foreach ($dataClasses as $type => $label) {
             if (DataObject::has_extension($type, FormResponseExtension::class)) {
-                $types[$type] = substr($label, strrpos($label, "\\") + 1);
+                $types[$label] = substr($label, strrpos($label, "\\") + 1);
             }
         }
 

--- a/src/FormSubmissionList.php
+++ b/src/FormSubmissionList.php
@@ -138,8 +138,8 @@ class FormSubmissionList extends DataObject
                 $fields->addFieldToTab('Root.Main', $grid);
             }
 
+            $fields->removeByName('AdditionalWorkflowDefinitions');
             if (class_exists(WorkflowDefinition::class) && DataObject::has_extension($this->TargetClass, WorkflowApplicable::class) && Permission::check('ADMIN')) {
-                $fields->removeByName('AdditionalWorkflowDefinitions');
                 $fields->addFieldsToTab('Root.Workflow', [
                     DropdownField::create('WorkflowDefinitionID', 'Workflow to apply', WorkflowDefinition::get()->map())
                         ->setEmptyString('Select a workflow')

--- a/src/FormSubmissionListAdmin.php
+++ b/src/FormSubmissionListAdmin.php
@@ -12,4 +12,9 @@ class FormSubmissionListAdmin extends ModelAdmin
         FormSubmissionList::class,
     ];
 
+    protected function init()
+    {
+        parent::init();
+        $this->showImportForm = false;
+    }
 }


### PR DESCRIPTION
- Fix `TargetClass` casing which causes an error when using CMS search form.
- Enable customisation of export columns (avoided using extension so it can be located on the object).
- Removed AdditionalWorkflowDefinitions` tab. Not sure this is okay, but it doesn't show anything?
- Add `AdminGroups` for changing configuration (regular admin can still do that, this was mostly about separating it from edit/view groups).
- Remove import button. Would have removed only from view/edit groups, but that seemed like an over-investment for something that probably wont/shouldn't be used here?