### PR TITLE
add(FormSubmissionList): Make buildExportColumns public

### DIFF
--- a/src/FormSubmissionList.php
+++ b/src/FormSubmissionList.php
@@ -163,7 +163,7 @@ class FormSubmissionList extends DataObject
      * Takes all the properties from a custom mapping of data
      * and makes them available in the CSV export
      */
-    protected function buildExportColumns($mapping, $instance)
+    public function buildExportColumns($mapping, $instance)
     {
         $fields = [];
         if (count($mapping)) {


### PR DESCRIPTION
Case:
- Client needs viewer users to be able to export
- Export button removed if user can't edit.
- Need to re-add button as part of extension.
- Need `buildExportColumns` to be public for the re-build.